### PR TITLE
addressing https://github.com/Gicotto/cacique-envision-pro-linux/issu…

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -45,7 +45,11 @@ echo "uinput" | sudo tee /etc/modules-load.d/uinput.conf
    Update `EVDEV_PATH` and `HIDRAW_PATH` in `scuf_virtual_pad.py` if they differ from `/dev/input/event3` and `/dev/hidraw0`.
 
 2. **Install systemd service**:
-   
+
+
+   IMPORTANT!: Update file path in scuf-virtual-controller.service to where scuf_virtual_pad.py exists (default where the repo is /path-to-repo/path-to-file/scuf_virtual_pad.py)
+   Example: ExecStart=/usr/bin/python3 /file/path/to/scuf_virtual_pad.py -> ExecStart=/usr/bin/python3 /home/user/repo/scuf_virtual_pad.py
+
    ```bash
    # Copy service file to systemd directory
    sudo cp scuf-virtual-controller.service /etc/systemd/system/
@@ -198,4 +202,4 @@ MIT
 
 ## Credits
 
-Created for the SCUF Envision Pro controller on Arch Linux. Tested with Citron emulator.
+Created for the SCUF Envision Pro controller on Arch Linux. Tested with Citron emulator. Author: Julian Cotto

--- a/scuf-virtual-controller.service
+++ b/scuf-virtual-controller.service
@@ -2,9 +2,10 @@
 Description=SCUF Envision Pro Virtual Controller Bridge
 After=multi-user.target
 
+# Important! Update /file/path/to/scuf_virtual_pad.py to the correct file path
 [Service]
 Type=simple
-ExecStart=/usr/bin/python3 /home/cotto/side_projects/cacique-envision-pro-linux/scuf_virtual_pad.py
+ExecStart=/usr/bin/python3 /file/path/to/scuf_virtual_pad.py
 Restart=always
 RestartSec=5
 User=root


### PR DESCRIPTION
Addressing https://github.com/Gicotto/cacique-envision-pro-linux/issues/1 - hard coded file path in scuf-virtual-controller.service. Updated README instructions to point path to appropriate location.

